### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Bare-bones Model Context Protocol server that lets Claude store personal finance transactions and later query them via semantic search. Transactions are persisted in ChromaDB for vector search plus a JSON ledger for backup.
 
+<a href="https://glama.ai/mcp/servers/@xinrong-meng/my-finance-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xinrong-meng/my-finance-mcp/badge" alt="My Finance Server MCP server" />
+</a>
+
 Run it alongside Claude Desktop and you get an AI bookkeeper that remembers your receipts, statements, and portfolios—then answers natural language questions about spending trends, allocations, or anything else you upload.
 
 ## Setup


### PR DESCRIPTION
This PR adds a badge for the [My Finance MCP Server](https://glama.ai/mcp/servers/@xinrong-meng/my-finance-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@xinrong-meng/my-finance-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xinrong-meng/my-finance-mcp/badge" alt="My Finance Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.